### PR TITLE
fix: export default components of typography

### DIFF
--- a/package.lib.json
+++ b/package.lib.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jupiter",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "main": "./index.js",
   "license": "MIT",
   "keywords": [

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -4,6 +4,12 @@ import Paragraph from './components/paragraph';
 import Title from './components/title';
 import Link from './components/link';
 
+export { default as Heading } from './components/heading';
+export { default as Text } from './components/text';
+export { default as Paragraph } from './components/paragraph';
+export { default as Title } from './components/title';
+export { default as Link } from './components/link';
+
 export default {
   Heading,
   Text,


### PR DESCRIPTION
Now we can import like this:

import { Text } from 'react-jupiter/typography';